### PR TITLE
Fix: Removed tns-core-modules package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "tns-core-modules": "^2.3.0",
     "tns-platform-declarations": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR fix an issue of duplicate download of `tns-core-modules` package of two different version, I am using higher version for `tns-core-modules` and when I try to use the package then it throws an error.Attached a  screenshot of an error for iOS device
<img width="1440" alt="Screenshot 2019-05-11 at 12 25 53 AM" src="https://user-images.githubusercontent.com/398390/57550861-2a5b9380-7385-11e9-837a-30c1b66ab9ae.png">
